### PR TITLE
Set up Vite build and GitHub Pages deployment for React Native Web app

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Cache npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-cache-${{ hashFiles('package-lock.json', 'package.json') }}
+          restore-keys: |
+            npm-cache-
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./dist
+          force_orphan: true

--- a/index.html
+++ b/index.html
@@ -4,10 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>React Native Web Form</title>
-    <link rel="stylesheet" href="./src/styles.css" />
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="./main.js"></script>
+    <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -3,12 +3,24 @@
   "version": "1.0.0",
   "description": "Simple React Native Web form example",
   "main": "index.js",
+  "type": "module",
   "scripts": {
-    "start": "python -m http.server 4173",
+    "start": "vite dev --host --port 4173",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
     "test": "echo \"No automated tests configured\""
   },
   "keywords": ["react-native-web", "example", "form"],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "dependencies": {
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-native-web": "0.19.12"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "4.3.3",
+    "vite": "5.4.2"
+  }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'https://esm.sh/react@18.3.1';
+import React, { useMemo, useState } from 'react';
 import {
   SafeAreaView,
   ScrollView,
@@ -7,7 +7,7 @@ import {
   TextInput,
   TouchableOpacity,
   View,
-} from 'https://esm.sh/react-native-web@0.19.12';
+} from 'react-native-web';
 
 const fields = [
   {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
-import React from 'https://esm.sh/react@18.3.1';
-import { AppRegistry } from 'https://esm.sh/react-native-web@0.19.12';
-import App from './src/App.js';
+import React from 'react';
+import { AppRegistry } from 'react-native-web';
+import App from './App';
+import './styles.css';
 
 AppRegistry.registerComponent('App', () => App);
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: './',
+  resolve: {
+    alias: {
+      'react-native$': 'react-native-web',
+    },
+  },
+  server: {
+    host: true,
+    port: 4173,
+  },
+});


### PR DESCRIPTION
## Summary
- replace CDN-based entry point with a Vite-powered React Native Web setup
- add local application bootstrap and styles import for bundling
- configure Vite with React plugin and native-web alias
- add GitHub Actions workflow that caches npm downloads, builds, and deploys the site to gh-pages
- set Vite base path for relative asset resolution on GitHub Pages

## Testing
- npm install --package-lock-only *(fails in container: npm registry 403 due to proxy restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f0e2ceea48323ad6cb8ad3ead2ca8)