### PR TITLE
Ensure Vite tooling installed in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@vitejs/plugin-react": "4.3.3",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-native-web": "0.19.12"
-      },
-      "devDependencies": {
-        "@vitejs/plugin-react": "4.3.3",
+        "react-native-web": "0.19.12",
         "vite": "5.4.2"
       }
     }
@@ -24,7 +22,7 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.3.tgz",
       "integrity": "sha512-PLACEHOLDER_OFFLINE",
-      "dev": true
+      "dev": false
     },
     "react": {
       "version": "18.2.0",
@@ -63,7 +61,7 @@
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.2.tgz",
       "integrity": "sha512-PLACEHOLDER_OFFLINE",
-      "dev": true
+      "dev": false
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,12 +15,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@vitejs/plugin-react": "4.3.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-native-web": "0.19.12"
-  },
-  "devDependencies": {
-    "@vitejs/plugin-react": "4.3.3",
+    "react-native-web": "0.19.12",
     "vite": "5.4.2"
-  }
+  },
+  "devDependencies": {}
 }


### PR DESCRIPTION
## Summary
- move Vite and @vitejs/plugin-react into production dependencies so builds work even when dev deps are omitted

## Testing
- not run (npm registry blocked in environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2b9f5108832384b0c2c489a3040c)